### PR TITLE
fix: added ValidateFunc to `corp_cloudwaf_instance`

### DIFF
--- a/provider/lib.go
+++ b/provider/lib.go
@@ -534,3 +534,32 @@ func validateActionResponseCode(val interface{}, key string) ([]string, []error)
 	rangeError := fmt.Errorf("received action responseCode '%d'. should be in 400-499 range", code)
 	return nil, []error{rangeError}
 }
+
+func validateRegion(val interface{}, key string) ([]string, []error) {
+	// https://docs.fastly.com/signalsciences/api/#_corps__corpName__cloudwafInstances_post
+	regionList := []string{
+		"us-east-1",
+		"us-west-1",
+		"af-south-1",
+		"ap-northeast-1",
+		"ap-northeast-2",
+		"ap-south-1",
+		"ap-southeast-1",
+		"ap-southeast-2",
+		"ca-central-1",
+		"eu-central-1",
+		"eu-north-1",
+		"eu-west-1",
+		"eu-west-2",
+		"eu-west-3",
+		"sa-east-1",
+		"us-east-2",
+		"us-west-2",
+	}
+
+	if existsInString(val.(string), regionList...) {
+		return nil, nil
+	}
+
+	return nil, []error{fmt.Errorf("received region name '%s' is invalid. should be in (%s)", val.(string), strings.Join(regionList, ", "))}
+}

--- a/provider/resource_corp_cloudwaf_instance.go
+++ b/provider/resource_corp_cloudwaf_instance.go
@@ -31,9 +31,10 @@ func resourceCorpCloudWAFInstance() *schema.Resource {
 				Required:    true,
 			},
 			"region": {
-				Type:        schema.TypeString,
-				Description: `Region the CloudWAF Instance is being deployed to. (Supported region: "us-east-1", "us-west-1", "af-south-1", "ap-northeast-1", "ap-northeast-2", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ca-central-1", "eu-central-1", "eu-north-1", "eu-west-1", "eu-west-2", "eu-west-3", "sa-east-1", "us-east-2", "us-west-2").`,
-				Required:    true,
+				Type:         schema.TypeString,
+				Description:  `Region the CloudWAF Instance is being deployed to. (Supported region: "us-east-1", "us-west-1", "af-south-1", "ap-northeast-1", "ap-northeast-2", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ca-central-1", "eu-central-1", "eu-north-1", "eu-west-1", "eu-west-2", "eu-west-3", "sa-east-1", "us-east-2", "us-west-2").`,
+				Required:     true,
+				ValidateFunc: validateRegion,
 			},
 			"tls_min_version": {
 				Type:        schema.TypeString,
@@ -69,6 +70,15 @@ func resourceCorpCloudWAFInstance() *schema.Resource {
 							Type:        schema.TypeString,
 							Description: `Set instance location to "direct" or "advanced".`,
 							Required:    true,
+							ValidateFunc: func(val interface{}, key string) (warns []string, errs []error) {
+								if val == nil {
+									return nil, nil
+								}
+								if existsInString(val.(string), "direct", "advanced") {
+									return nil, nil
+								}
+								return nil, []error{errors.New(`instance_location must be "direct" or "advanced"`)}
+							},
 						},
 						"client_ip_header": {
 							Type:        schema.TypeString,
@@ -110,6 +120,7 @@ func resourceCorpCloudWAFInstance() *schema.Resource {
 										Description: "List of domain or request URIs, up to 100 entries.",
 										Required:    true,
 										Elem:        &schema.Schema{Type: schema.TypeString},
+										MaxItems:    100,
 									},
 									"origin": {
 										Type:        schema.TypeString,

--- a/provider/resource_site.go
+++ b/provider/resource_site.go
@@ -57,7 +57,7 @@ func resourceSite() *schema.Resource {
 				Type:        schema.TypeMap,
 				Description: "The sites primary Agent key",
 				Computed:    true,
-				Sensitive: true,
+				Sensitive:   true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": {
@@ -65,12 +65,12 @@ func resourceSite() *schema.Resource {
 							Computed: true,
 						},
 						"secret_key": {
-							Type:      schema.TypeString,
-							Computed:  true,
+							Type:     schema.TypeString,
+							Computed: true,
 						},
 						"access_key": {
-							Type:      schema.TypeString,
-							Computed:  true,
+							Type:     schema.TypeString,
+							Computed: true,
 						},
 					},
 				},


### PR DESCRIPTION
Hi, 

I added some validateFunc to `corp_cloudwaf_instance` resource.

- `region`
	- Wheter is in region list. ([doc](https://docs.fastly.com/signalsciences/api/#_corps__corpName__cloudwafInstances_post))
- `instance_location`
	- whether "direct" or "advanced"
- `workspace_configs.routes.domains`
	- Wheter less than equal 100 entries